### PR TITLE
Add cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     # Install tools, required for building
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        # In general...
+        # For building (will be removed)
         autoconf \
         build-essential \
         curl \
@@ -43,7 +43,10 @@ RUN \
         # For Honcho
         python \
         python-pip \
-        python-pkg-resources && \
+        python-pkg-resources \
+
+        # Fron crontab
+        cron && \
 
     pip install honcho && \
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 nginx: /usr/local/sbin/nginx
 phpfpm: /usr/local/sbin/php-fpm
+cron: /usr/sbin/cron -f

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Xdebug was installed mainly with the idea of providing code coverage for PHPUnit
 configured for any specific use case. You can [configure Xdebug](https://xdebug.org/docs/all) via
 `php.ini` if desired.
 
+### Crontab
+
+Crontab is already installed. In order to deploy a crontab file, you would need
+to store a valid crontab file to `/crontab/USERNAME`, where `USERNAME` has to
+be an **existing** user. This is important, because any contrab instructions
+will be executed as the user, specified by the filename.
+
+Usually, you would like to run all your crontab instructions as **www-data**.
+So you should mount your crontab file to `/crontab/www-data` (or under
+`/crontab/root` if needed - needless to say you should try to avoid this
+whenever possible).
+
 ### Honcho
 
 If you want to overwrite the default Honcho configuration - mount your custom `Procfile` file at `/`.

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -22,6 +22,14 @@ if [[ $ENABLE_XDEBUG == "1" ]]; then
     echo "zend_extension = /usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so" >> /usr/local/lib/php.ini
 fi
 
+# Deploy available crontabs
+if [[ -d /crontab ]]; then
+    for crontab_file in $(ls /crontab); do
+        crontab -u $crontab_file /crontab/$crontab_file
+    done
+fi
+
+# Start Honcho
 if [[ $1 == "server" ]]; then
     exec honcho -d / start
 fi


### PR DESCRIPTION
Add crontab daemon.

Valid crontab must be mounted to `/crontab/USERNAME`, where `USERNAME` has to be an existing user in the container. Any crontab instructions in a file will be executed as this user.